### PR TITLE
feat: add /app/local to PYTHONPATH for local dev setups

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ ENV PYTHONUNBUFFERED 1
 ENV ENVIRONMENT prod
 ENV TESTING 0
 
-ENV PYTHONPATH=/app
+ENV PYTHONPATH=/app:/app/local
 
 COPY startup /startup
 COPY apis_instance /app/


### PR DESCRIPTION
This way devs can put their custom packages into the `local` folder of
their instance.
