### PR TITLE
feat: add initialrevsions Django command

### DIFF
--- a/startup/050-createinitialrevisions
+++ b/startup/050-createinitialrevisions
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+source /startup/common
+[[ $CREATE_INITIAL_REVISIONS == "True" ]] && red django-admin createinitialrevisions


### PR DESCRIPTION
The `createinitialrevsision` command should be run to create initial
revisions for the `django-reversion` app.
