### PR TITLE
Update add-to-project workflow: upgrade version + add workflow trigger

### DIFF
--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -1,10 +1,13 @@
 # SPDX-FileCopyrightText: 2024 K Kollmann
 # SPDX-License-Identifier: MIT
 
-name: Add repository issues to Prosnet project
+name: Add issues, PRs to Prosnet project
 
 on:
   issues:
+    types:
+      - opened
+  pull_request:
     types:
       - opened
 

--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   add-to-project:
-    uses: acdh-oeaw/prosnet-workflows/.github/workflows/add-to-project.yml@v0.4.0
+    uses: acdh-oeaw/prosnet-workflows/.github/workflows/add-to-project.yml@v0.4.7
     secrets:
       ADD_TO_PROJECT_TOKEN: ${{ secrets.ADD_TO_PROJECT_TOKEN }}
     with:


### PR DESCRIPTION
* update version of callable workflow to latest `prosnet-workflows` release
* trigger workflow also on PRs in addition to issues – #47   